### PR TITLE
Add color support and style configurability

### DIFF
--- a/example.style
+++ b/example.style
@@ -1,0 +1,63 @@
+# This file configures the curses styles corresponding to GLK styles for
+# glkterm.
+# Very basic example of a style file, using only 8 colors.
+#
+# There are two categories, the styles for textbuffer and textgrid windows.
+#
+# Each line consists of the name of the style, like 'Normal', the foreground
+# color, the background color, and a list of attributes seperated by spaces.
+# For non-color builds of glkterm both colors are ignored.
+#
+# The number of colors available depends on the terminal setting (TERM
+# environment variable). It can be queried using `tput colors` from the command
+# line. Some older terminals have only 8 colors available, whereas modern
+# terminals usually have 256. The special value -1 is used to specify the
+# terminal default.
+#
+# Available attributes are:
+#   STANDOUT    Best highlighting mode of the terminal (usually same as REVERSE).
+#   UNDERLINE   Underlining.
+#   REVERSE     Reverse-video (swap foreground and background).
+#   BLINK       Blinking.
+#   DIM         Half bright.
+#   BOLD        Bold or extra bright.
+#   ALTCHARSET  Alternate character set.
+#   INVIS       Invisibility.
+#   PROTECT     Protected mode.
+#
+# Note that not all terminals implement all attributes. Unknown attributes are ignored.
+# The background of Normal text is used as overall window background.
+#
+[separator] # separators between windows
+Normal        = -1, -1,
+
+[textbuffer] # main text area
+# Style         fg  bg  attrs
+Normal        = -1, -1,
+Emphasized    = -1, -1, UNDERLINE
+Preformatted  = -1, -1,
+Header        = 4, -1, BOLD
+Subheader     = 5, -1, BOLD
+Alert         = -1, -1, REVERSE
+Note          = -1, -1, UNDERLINE
+BlockQuote    = -1, -1,
+Input         = -1, -1, BOLD
+User1         = 2, -1,
+User2         = 3, -1,
+
+[textgrid] # information area
+# Style         fg  bg  attrs
+Normal        = -1, -1,
+Emphasized    = -1, -1, UNDERLINE
+Preformatted  = -1, -1,
+Header        = -1, -1, BOLD
+Subheader     = -1, -1, BOLD
+Alert         = -1, -1, REVERSE
+Note          = -1, -1, UNDERLINE
+BlockQuote    = -1, -1,
+Input         = -1, -1, BOLD
+User1         = -1, -1,
+User2         = -1, -1,
+
+#[blub]
+

--- a/example2.style
+++ b/example2.style
@@ -1,0 +1,37 @@
+# This file configures the curses styles corresponding to GLK styles for
+# glkterm.
+# 
+# Theme loosely based on the wombat256 color theme for vim, uses 256 colors.
+#
+[separator] # separators between windows
+Normal        = 111, 234,
+
+[textbuffer] # main text area
+# Style         fg  bg  attrs
+Normal        = 252, 234,
+Emphasized    = 173, 234, UNDERLINE
+Preformatted  = 252, 234,
+Header        = 16, 152, BOLD
+Subheader     = 16, 248, BOLD
+Alert         = 252, 234, REVERSE
+Note          = 192, 234, UNDERLINE
+BlockQuote    = 246, 234,
+Input         = 252, 234, BOLD
+User1         = 229, 234,
+User2         = 113, 234,
+
+[textgrid] # information area
+# Style         fg  bg  attrs
+Normal        = 252, 234,
+Emphasized    = 173, 234, UNDERLINE
+Preformatted  = 252, 234,
+Header        = 16, 152, BOLD
+Subheader     = 16, 248, BOLD
+Alert         = 252, 234, REVERSE
+Note          = 192, 234, UNDERLINE
+BlockQuote    = 246, 234,
+Input         = 252, 234, BOLD
+User1         = 229, 234,
+User2         = 113, 234,
+
+

--- a/gtoption.h
+++ b/gtoption.h
@@ -226,5 +226,15 @@
     The second is for a keyboard that can only generate 7-bit ASCII.
 */
 
+#define OPT_USE_COLORS
+
+/* OPT_USE_COLORS can be defined to use ncurses color support.
+ * All modern ncurses libraries support colors, but if yours doesn't -
+ * you get an error on init_pair or start_colors - this can be undefined.
+ *
+ * Note that it doesn't matter whether your terminal supports colors. If your
+ * terminal doesn't support colors, they won't be used either way.
+ */
+
 #endif /* GTOPTION_H */
 

--- a/gtstyle.c
+++ b/gtstyle.c
@@ -25,7 +25,7 @@ void glk_stylehint_clear(glui32 wintype, glui32 styl, glui32 hint)
 
 glui32 glk_style_distinguish(window_t *win, glui32 styl1, glui32 styl2)
 {
-    chtype *styleattrs;
+    int *styleattrs;
 
     if (!win) {
         gli_strict_warning("style_distinguish: invalid ref");
@@ -57,7 +57,7 @@ glui32 glk_style_distinguish(window_t *win, glui32 styl1, glui32 styl2)
 glui32 glk_style_measure(window_t *win, glui32 styl, glui32 hint, 
     glui32 *result)
 {
-    chtype *styleattrs;
+    int *styleattrs;
     glui32 dummy;
 
     if (!win) {

--- a/gtw_buf.c
+++ b/gtw_buf.c
@@ -14,7 +14,23 @@
 #include "gtw_buf.h"
 
 /* Array of curses.h attribute values, one for each style. */
-chtype win_textbuffer_styleattrs[style_NUMSTYLES];
+int win_textbuffer_styleattrs[style_NUMSTYLES];
+
+/* Curses foreground, background and attribute information, one for each style. */
+int win_textbuffer_styles[style_NUMSTYLES][3]={
+    /*                   fg   bg  attrs */
+    /* Normal */       { -1,  -1, 0},
+    /* Emphasized */   { -1,  -1, A_UNDERLINE },
+    /* Preformatted */ { -1,  -1, 0},
+    /* Header */       { -1,  -1, A_BOLD },
+    /* Subheader */    { -1,  -1, A_BOLD },
+    /* Alert */        { -1,  -1, A_REVERSE },
+    /* Note */         { -1,  -1, A_UNDERLINE },
+    /* BlockQuote */   { -1,  -1, 0},
+    /* Input */        { -1,  -1, A_BOLD },
+    /* User1 */        { -1,  -1, 0},
+    /* User2 */        { -1,  -1, 0}
+};
 
 /* Maximum buffer size. The slack value is how much larger than the size 
     we should get before we trim. */
@@ -613,7 +629,7 @@ static void updatetext(window_textbuffer_t *dwin)
                             addch(*cx);
                     }
                 }
-                attrset(0);
+                attrset(win_textbuffer_styleattrs[0]);
                 gli_print_spaces(dwin->width - count);
             }
             else {
@@ -622,6 +638,7 @@ static void updatetext(window_textbuffer_t *dwin)
                 gli_print_spaces(dwin->width);
             }
         }
+        attrset(0);
     }
 }
 

--- a/gtw_buf.h
+++ b/gtw_buf.h
@@ -91,7 +91,8 @@ typedef struct window_textbuffer_struct {
     gidispatch_rock_t inarrayrock;
 } window_textbuffer_t;
 
-extern chtype win_textbuffer_styleattrs[style_NUMSTYLES];
+extern int win_textbuffer_styleattrs[style_NUMSTYLES];
+extern int win_textbuffer_styles[style_NUMSTYLES][3];
 
 extern window_textbuffer_t *win_textbuffer_create(window_t *win);
 extern void win_textbuffer_destroy(window_textbuffer_t *dwin);

--- a/gtw_grid.c
+++ b/gtw_grid.c
@@ -25,7 +25,23 @@ static void import_input_line(tgline_t *ln, int offset, void *buf,
     int unicode, long len);
 
 /* Array of curses.h attribute values, one for each style. */
-chtype win_textgrid_styleattrs[style_NUMSTYLES];
+int win_textgrid_styleattrs[style_NUMSTYLES];
+
+/* Curses foreground, background and attribute information, one for each style. */
+int win_textgrid_styles[style_NUMSTYLES][3]={
+    /*                   fg   bg  attrs */
+    /* Normal */       { -1,  -1, 0},
+    /* Emphasized */   { -1,  -1, A_UNDERLINE },
+    /* Preformatted */ { -1,  -1, 0},
+    /* Header */       { -1,  -1, A_BOLD },
+    /* Subheader */    { -1,  -1, A_BOLD },
+    /* Alert */        { -1,  -1, A_REVERSE },
+    /* Note */         { -1,  -1, A_UNDERLINE },
+    /* BlockQuote */   { -1,  -1, 0},
+    /* Input */        { -1,  -1, A_BOLD },
+    /* User1 */        { -1,  -1, 0},
+    /* User2 */        { -1,  -1, 0}
+};
 
 /* This macro sets the appropriate dirty values, when a single character
     (at px, py) is changed. */

--- a/gtw_grid.h
+++ b/gtw_grid.h
@@ -35,7 +35,8 @@ typedef struct window_textgrid_struct {
     gidispatch_rock_t inarrayrock;
 } window_textgrid_t;
 
-extern chtype win_textgrid_styleattrs[style_NUMSTYLES];
+extern int win_textgrid_styleattrs[style_NUMSTYLES];
+extern int win_textgrid_styles[style_NUMSTYLES][3];
 
 extern window_textgrid_t *win_textgrid_create(window_t *win);
 extern void win_textgrid_destroy(window_textgrid_t *dwin);

--- a/gtw_pair.c
+++ b/gtw_pair.c
@@ -12,6 +12,17 @@
 #include "glkterm.h"
 #include "gtw_pair.h"
 
+/* Array of curses.h attribute values, one for each style. */
+int win_separator_styleattrs[style_NUMSTYLES];
+
+/* Curses foreground, background and attribute information, one for each style. 
+ * Only the normal style is used here.
+ */
+int win_separator_styles[style_NUMSTYLES][3]={
+    /*                   fg   bg  attrs */
+    /* Normal */       { -1,  -1, 0},
+};
+
 window_pair_t *win_pair_create(window_t *win, glui32 method, window_t *key, 
     glui32 size)
 {
@@ -183,6 +194,7 @@ void win_pair_redraw(window_t *win)
         return;
         
     dwin = win->data;
+    attrset(win_separator_styleattrs[0]);
 
     if (dwin->vertical) {
         if (dwin->splitwidth) {
@@ -211,6 +223,7 @@ void win_pair_redraw(window_t *win)
             }
         }
     }
+    attrset(0);
     
     gli_window_redraw(dwin->child1);
     gli_window_redraw(dwin->child2);

--- a/gtw_pair.h
+++ b/gtw_pair.h
@@ -24,6 +24,9 @@ typedef struct window_pair_struct {
     
 } window_pair_t;
 
+extern int win_separator_styleattrs[style_NUMSTYLES];
+extern int win_separator_styles[style_NUMSTYLES][3];
+
 extern window_pair_t *win_pair_create(window_t *win, glui32 method, 
     window_t *key, glui32 size);
 extern void win_pair_destroy(window_pair_t *dwin);


### PR DESCRIPTION
Color support for glkterm. Makes it possible to configure a color pair for each textbuf/textgrid style.

Defines a `OPT_USE_COLORS` option which can be disabled for (n)curses implementations that don't implement color support.

Provide a `-style` command line option to load a 'style sheet' specifying the curses style for every glk style.

Two example style files are provided.
