### PR TITLE
Replaced tmpnam() with a safer mkstemp().

### DIFF
--- a/gtfref.c
+++ b/gtfref.c
@@ -112,15 +112,15 @@ static char *gli_suffix_for_usage(glui32 usage)
 
 frefid_t glk_fileref_create_temp(glui32 usage, glui32 rock)
 {
-    char *filename;
+    char filename[] = "/tmp/glktermXXXXXX";
     fileref_t *fref;
     
     /* This is a pretty good way to do this on Unix systems. On Macs,
         it's pretty bad, but this library won't be used on the Mac 
         -- I hope. I have no idea about the DOS/Windows world. */
         
-    filename = tmpnam(NULL);
-    
+    mkstemp(filename);
+
     fref = gli_new_fileref(filename, usage, rock);
     if (!fref) {
         gli_strict_warning("fileref_create_temp: unable to create fileref.");


### PR DESCRIPTION
Replaced tmpnam() with a safer mkstemp().