### PR TITLE
Enhancements discussed on intfiction.org

### DIFF
--- a/cgdate.c
+++ b/cgdate.c
@@ -106,7 +106,7 @@ void glk_current_time(glktimeval_t *time)
         return;
     }
 
-    gli_timestamp_to_time(tv.tv_sec, tv.tv_usec, time);
+    gli_timestamp_to_time(tv.tv_sec+pref_clock_skew, tv.tv_usec, time);
 }
 
 glsi32 glk_current_simple_time(glui32 factor)
@@ -123,7 +123,7 @@ glsi32 glk_current_simple_time(glui32 factor)
         return 0;
     }
 
-    return gli_simplify_time(tv.tv_sec, factor);
+    return gli_simplify_time(tv.tv_sec+pref_clock_skew, factor);
 }
 
 void glk_time_to_date_utc(glktimeval_t *time, glkdate_t *date)

--- a/glkterm.h
+++ b/glkterm.h
@@ -117,6 +117,7 @@ struct glk_fileref_struct {
     char *filename;
     int filetype;
     int textmode;
+    int readonly;
 
     gidispatch_rock_t disprock;
     fileref_t *next, *prev; /* in the big linked list of filerefs */
@@ -145,6 +146,7 @@ extern window_t *gli_rootwin;
 extern window_t *gli_focuswin;
 extern grect_t content_box;
 extern void (*gli_interrupt_handler)(void);
+extern int gli_exited;
 
 /* The following typedefs are copied from cheapglk.h. They support the
    tables declared in cgunigen.c. */
@@ -193,6 +195,35 @@ extern int pref_window_borders;
 extern int pref_precise_timing;
 extern int pref_historylen;
 extern int pref_prompt_defaults;
+/* Extended pref */
+extern int pref_style_override;
+extern int pref_border_graphics;
+extern unsigned long pref_border_style;
+extern int pref_use_colors;
+extern int pref_clear_message;
+extern int pref_auto_focus;
+extern int pref_more_message;
+extern int pref_typable_controls;
+extern int pref_typable_specials;
+#ifdef OPT_USE_MKSTEMP
+extern char*pref_temporary_filename;
+#endif
+extern int pref_readonly;
+extern int pref_auto_suffix;
+extern int pref_prompt_raw_filename;
+extern signed long pref_clock_skew;
+extern int pref_restrict_files;
+extern int pref_pause_warning;
+extern int pref_more_exit;
+
+/* Filename mapping */
+typedef struct {
+  char*glkname;
+  char*native;
+  char writable;
+} Filename_Mapping;
+extern Filename_Mapping*filename_mapping;
+extern int num_filename_mapping;
 
 /* Declarations of library internal functions. */
 

--- a/gtgestal.c
+++ b/gtgestal.c
@@ -18,8 +18,10 @@ glui32 glk_gestalt(glui32 id, glui32 val)
 
 glui32 glk_gestalt_ext(glui32 id, glui32 val, glui32 *arr, glui32 arrlen)
 {
+    static int impl;
     int ix;
     
+    impl=TRUE;
     switch (id) {
         
         case gestalt_Version:
@@ -49,7 +51,7 @@ glui32 glk_gestalt_ext(glui32 id, glui32 val, glui32 *arr, glui32 arrlen)
                     || val == keycode_Up || val == keycode_Down
                     || val == keycode_Return || val == keycode_Delete
                     || val == keycode_Escape)
-                    return TRUE;
+                    return (val == keycode_Return || pref_typable_specials);
                 else
                     return FALSE;
             }
@@ -118,10 +120,11 @@ glui32 glk_gestalt_ext(glui32 id, glui32 val, glui32 *arr, glui32 arrlen)
             return TRUE;
 
         case gestalt_LineTerminators:
-            return TRUE;
+            return pref_typable_specials;
         case gestalt_LineTerminatorKey:
             /* GlkTerm never uses the escape or function keys for anything,
                so we'll allow them to be line terminators. */
+            if (!pref_typable_specials) return FALSE;
             if (val == keycode_Escape)
                 return TRUE;
             if (val >= keycode_Func12 && val <= keycode_Func1)
@@ -134,7 +137,16 @@ glui32 glk_gestalt_ext(glui32 id, glui32 val, glui32 *arr, glui32 arrlen)
         case gestalt_ResourceStream:
             return TRUE;
 
+        case 0x1400: /* gestalt_Gestalt */
+            glk_gestalt_ext(val,0,NULL,0);
+            return impl;
+
+        case 0x1407: /* gestalt_CharInputExt */
+            if(val=='\031' || val=='\026') return char_typable_table[val]?0x22:0;
+            else return char_typable_table[val]?0x33:0;
+
         default:
+            impl=FALSE;
             return 0;
 
     }

--- a/gtmessag.c
+++ b/gtmessag.c
@@ -26,8 +26,16 @@ void gli_msgline_warning(char *msg)
     if (!pref_messageline)
         return;
         
-    sprintf(buf, "Glk library error: %s", msg);
+    snprintf(buf, 256, "Glk library error: %s", msg);
     gli_msgline(buf);
+    
+    if(pref_pause_warning) {
+      move(content_box.bottom, 0);
+      refresh();
+      while(getch()==ERR && !just_killed);
+      gli_msgline("");
+    }
+    if(just_killed) gli_fast_exit();
 }
 
 void gli_msgline(char *msg)

--- a/gtmisc.c
+++ b/gtmisc.c
@@ -29,6 +29,8 @@ gidispatch_rock_t (*gli_register_arr)(void *array, glui32 len, char *typecode) =
 void (*gli_unregister_arr)(void *array, glui32 len, char *typecode, 
     gidispatch_rock_t objrock) = NULL;
 
+int gli_exited=FALSE;
+
 static char *char_A0_FF_to_ascii[6*16] = {
     " ", "!", "c", "Lb", NULL, "Y", "|", NULL,
     NULL, "(C)", NULL, "<<", NULL, "-", "(R)", NULL,
@@ -99,7 +101,7 @@ void gli_initialize_misc()
                 || ix == '\033')            /* parsed as keycode_Escape */
                 cantype = FALSE;
             else
-                cantype = TRUE;
+                cantype = pref_typable_controls;
             /* The newline is printable, but no other control characters. */
             if (ix == '\012')
                 canprint = TRUE;
@@ -142,7 +144,18 @@ void gli_initialize_misc()
 
 void glk_exit()
 {   
-    gli_msgin_getchar("Hit any key to exit.", TRUE);
+    if(pref_more_exit && gli_rootwin) {
+      event_t ev;
+      gli_exited=TRUE;
+      pref_auto_focus=TRUE;
+      pref_clear_message=TRUE;
+      for(;;) {
+        glk_select(&ev);
+        if(ev.type==evtype_CharInput) break;
+      }
+    } else {
+      gli_msgin_getchar("Hit any key to exit.", TRUE);
+    }
 
     gli_streams_close_all();
 

--- a/gtoption.h
+++ b/gtoption.h
@@ -17,7 +17,7 @@
 /* Options: */
 
 #define LIBRARY_VERSION "1.0.4"
-#define LIBRARY_PORT "Generic"
+#define LIBRARY_PORT "Enhanced"
 
 /* If you change this code substantially, you should change the
     LIBRARY_PORT definition to something which explains what the
@@ -79,6 +79,13 @@
     is also defined.
 */
 
+
+#define OPT_USE_MKSTEMP
+
+/* OPT_USE_MKSTEMP should be defined if mkstemp() is available. See the
+    user setting documentation for details about the template.
+*/
+
 /* #define NO_MEMMOVE */
 
 /* NO_MEMMOVE should be defined if your standard library doesn't
@@ -125,7 +132,6 @@
 }
 */
 
-/*
 #define OPT_AO_FF_OUTPUT {  \
     0, 0, 0, 0, 0, 0, 0, 0,  \
     0, 0, 0, 0, 0, 0, 0, 0,  \
@@ -140,8 +146,8 @@
     0, 0, 0, 0, 0, 0, 0, 0,  \
     0, 0, 0, 0, 0, 0, 0, 0,  \
 }
-*/
 
+/*
 #define OPT_AO_FF_OUTPUT {  \
     '\312', '\301', '\242', '\243',  0    , '\264',  0    , '\244',  \
     '\254', '\251', '\273', '\307', '\302', '\320', '\250',  0    ,  \
@@ -156,6 +162,7 @@
      0    , '\226', '\230', '\227', '\231', '\233', '\232', '\326',  \
     '\277', '\235', '\234', '\236', '\237',  0    ,  0    , '\330',  \
 }
+*/
 
 /* OPT_AO_FF_OUTPUT should be defined as a translation table. This is
     ignored if OPT_NATIVE_LATIN_1 is defined. 
@@ -172,23 +179,24 @@
     is for the standard Macintosh character set.
 */
 
-#define OPT_AO_FF_TYPABLE {  \
-    1, 1, 1, 1, 1, 1, 1, 1,  \
-    1, 1, 1, 1, 1, 1, 1, 1,  \
-    1, 1, 1, 1, 1, 1, 1, 1,  \
-    1, 1, 1, 1, 1, 1, 1, 1,  \
-    1, 1, 1, 1, 1, 1, 1, 1,  \
-    1, 1, 1, 1, 1, 1, 1, 1,  \
-    1, 1, 1, 1, 1, 1, 1, 1,  \
-    1, 1, 1, 1, 1, 1, 1, 1,  \
-    1, 1, 1, 1, 1, 1, 1, 1,  \
-    1, 1, 1, 1, 1, 1, 1, 1,  \
-    1, 1, 1, 1, 1, 1, 1, 1,  \
-    1, 1, 1, 1, 1, 1, 1, 1,  \
-}
-
 /*
 #define OPT_AO_FF_TYPABLE {  \
+    1, 1, 1, 1, 1, 1, 1, 1,  \
+    1, 1, 1, 1, 1, 1, 1, 1,  \
+    1, 1, 1, 1, 1, 1, 1, 1,  \
+    1, 1, 1, 1, 1, 1, 1, 1,  \
+    1, 1, 1, 1, 1, 1, 1, 1,  \
+    1, 1, 1, 1, 1, 1, 1, 1,  \
+    1, 1, 1, 1, 1, 1, 1, 1,  \
+    1, 1, 1, 1, 1, 1, 1, 1,  \
+    1, 1, 1, 1, 1, 1, 1, 1,  \
+    1, 1, 1, 1, 1, 1, 1, 1,  \
+    1, 1, 1, 1, 1, 1, 1, 1,  \
+    1, 1, 1, 1, 1, 1, 1, 1,  \
+}
+*/
+
+#define OPT_AO_FF_TYPABLE {  \
     0, 0, 0, 0, 0, 0, 0, 0,  \
     0, 0, 0, 0, 0, 0, 0, 0,  \
     0, 0, 0, 0, 0, 0, 0, 0,  \
@@ -202,7 +210,6 @@
     0, 0, 0, 0, 0, 0, 0, 0,  \
     0, 0, 0, 0, 0, 0, 0, 0,  \
 }
-*/
 
 /* OPT_AO_FF_TYPABLE should be defined as a table of which characters
     can actually be typed by the player.

--- a/gtstream.c
+++ b/gtstream.c
@@ -232,6 +232,12 @@ strid_t glk_stream_open_file(fileref_t *fref, glui32 fmode,
         gli_strict_warning("stream_open_file: invalid fileref ref.");
         return 0;
     }
+
+    /* User preference to force read-only */
+    if(fref->readonly && fmode!=filemode_Read) {
+        gli_strict_warning("stream_openfile: trying to open read-only file for writing.");
+        return 0;
+    }
     
     /* The spec says that Write, ReadWrite, and WriteAppend create the
        file if necessary. However, fopen(filename, "r+") doesn't create
@@ -347,7 +353,7 @@ strid_t glk_stream_open_file_uni(fileref_t *fref, glui32 fmode,
 {
     strid_t str = glk_stream_open_file(fref, fmode, rock);
     /* Unlovely, but it works in this library */
-    str->unicode = TRUE;
+    if(str) str->unicode = TRUE;
     return str;
 }
 

--- a/gtw_pair.h
+++ b/gtw_pair.h
@@ -29,3 +29,6 @@ extern window_pair_t *win_pair_create(window_t *win, glui32 method,
 extern void win_pair_destroy(window_pair_t *dwin);
 extern void win_pair_rearrange(window_t *win, grect_t *box);
 extern void win_pair_redraw(window_t *win);
+extern void win_pair_calc_border(window_t *win);
+
+extern char*border_buf;

--- a/main.c
+++ b/main.c
@@ -16,6 +16,9 @@
 #include "gtw_buf.h"
 #include "gtw_grid.h"
 
+/* Make gcc shut up about "...pointer from integer without a cast" */
+char *strdup(const char *s);
+
 /* Declarations of preferences flags. */
 int pref_printversion = FALSE;
 int pref_screenwidth = 0;

--- a/main.c
+++ b/main.c
@@ -13,6 +13,8 @@
 #include "glk.h"
 #include "glkterm.h"
 #include "glkstart.h"
+#include "gtw_buf.h"
+#include "gtw_grid.h"
 
 /* Declarations of preferences flags. */
 int pref_printversion = FALSE;
@@ -25,6 +27,29 @@ int pref_window_borders = FALSE;
 int pref_precise_timing = FALSE;
 int pref_historylen = 20;
 int pref_prompt_defaults = TRUE;
+/* Extended pref */
+int pref_style_override = FALSE;
+int pref_border_graphics = FALSE;
+unsigned long pref_border_style = 0;
+int pref_use_colors = FALSE;
+int pref_clear_message = FALSE;
+int pref_auto_focus = TRUE;
+int pref_more_message = FALSE;
+int pref_typable_controls = TRUE;
+int pref_typable_specials = TRUE;
+#ifdef OPT_USE_MKSTEMP
+char*pref_temporary_filename = NULL;
+#endif
+int pref_readonly = FALSE;
+int pref_auto_suffix = TRUE;
+int pref_prompt_raw_filename = FALSE;
+signed long pref_clock_skew = 0;
+int pref_restrict_files = FALSE;
+int pref_pause_warning = FALSE;
+int pref_more_exit = FALSE;
+
+Filename_Mapping*filename_mapping=0;
+int num_filename_mapping=0;
 
 /* Some constants for my wacky little command-line option parser. */
 #define ex_Void (0)
@@ -38,10 +63,158 @@ static int extract_value(int argc, char *argv[], char *optname, int type,
     int *argnum, int *result, int defval);
 static int string_to_bool(char *str);
 
+static chtype parse_style(char*buf) {
+  chtype t=0;
+  while(*buf) {
+    switch(*buf++) {
+      case 's': t|=A_STANDOUT; break;
+      case 'u': t|=A_UNDERLINE; break;
+      case 'r': t|=A_REVERSE; break;
+      case 'k': t|=A_BLINK; break;
+      case 'd': t|=A_DIM; break;
+      case 'b': t|=A_BOLD; break;
+      case 'p': t|=A_PROTECT; break;
+      case 'i': t|=A_INVIS; break;
+      case 'a': t|=A_ALTCHARSET; break;
+      case ' ': case '\t': break;
+      case '0': t|=COLOR_PAIR(8); break;
+      case '1': t|=COLOR_PAIR(1); break;
+      case '2': t|=COLOR_PAIR(2); break;
+      case '3': t|=COLOR_PAIR(3); break;
+      case '4': t|=COLOR_PAIR(4); break;
+      case '5': t|=COLOR_PAIR(5); break;
+      case '6': t|=COLOR_PAIR(6); break;
+      case '7': t|=COLOR_PAIR(7); break;
+      default:
+        printf("Invalid style: %c\n",buf[-1]);
+        exit(1);
+    }
+  }
+  return t;
+}
+
+#define USER_OPTION(a,b) if(!strncmp(a"=",buf,sizeof(a))) { buf+=sizeof(a); while(*buf==' ' || *buf=='\t') buf++; b; return; }
+static void user_option(char*buf) {
+  int i,j;
+  chtype t;
+  USER_OPTION("screenwidth",pref_screenwidth=strtol(buf,0,10));
+  USER_OPTION("screenheight",pref_screenheight=strtol(buf,0,10));
+  USER_OPTION("messageline",pref_messageline=string_to_bool(buf));
+  USER_OPTION("reverse_textgrids",pref_reverse_textgrids=string_to_bool(buf));
+  USER_OPTION("window_borders",{
+    pref_override_window_borders=TRUE;
+    pref_window_borders=string_to_bool(buf);
+  });
+#ifdef OPT_TIMED_INPUT
+  USER_OPTION("precise_timing",pref_precise_timing=string_to_bool(buf));
+#endif
+  USER_OPTION("historylen",pref_historylen=strtol(buf,0,10));
+  USER_OPTION("prompt_defaults",pref_prompt_defaults=string_to_bool(buf));
+  USER_OPTION("style_override",pref_style_override=string_to_bool(buf));
+  USER_OPTION("border_graphics",pref_border_graphics=string_to_bool(buf));
+  USER_OPTION("border_style",pref_border_style=parse_style(buf));
+  USER_OPTION("use_colors",pref_use_colors=string_to_bool(buf));
+  USER_OPTION("clear_message",pref_clear_message=string_to_bool(buf));
+  USER_OPTION("auto_focus",pref_auto_focus=string_to_bool(buf));
+  USER_OPTION("more_message",pref_more_message=string_to_bool(buf));
+  USER_OPTION("typable_controls",pref_typable_controls=string_to_bool(buf));
+  USER_OPTION("typable_specials",pref_typable_specials=string_to_bool(buf));
+#ifdef OPT_USE_MKSTEMP
+  USER_OPTION("temporary_filename",{
+    pref_temporary_filename=strdup(buf);
+    if(!pref_temporary_filename) goto memerr;
+    if(strlen(pref_temporary_filename)<6 || strcmp(pref_temporary_filename+strlen(pref_temporary_filename)-6,"XXXXXX")) {
+      printf("Temporary filename must end with \"XXXXXX\"\n");
+      exit(1);
+    }
+  });
+#endif
+  USER_OPTION("readonly",pref_readonly=string_to_bool(buf));
+  USER_OPTION("auto_suffix",pref_auto_suffix=string_to_bool(buf));
+  USER_OPTION("prompt_raw_filename",pref_prompt_raw_filename=string_to_bool(buf));
+  USER_OPTION("clock_skew",pref_clock_skew=strtol(buf,0,10));
+  USER_OPTION("restrict_files",pref_restrict_files=string_to_bool(buf));
+  USER_OPTION("pause_warning",pref_pause_warning=string_to_bool(buf));
+  USER_OPTION("more_exit",pref_more_exit=string_to_bool(buf));
+  if(*buf=='S' || *buf=='B' || *buf=='G') {
+    j=*buf;
+    i=strtol(buf+1,&buf,10);
+    if(i>=0 && i<style_NUMSTYLES && *buf=='=') {
+      t=parse_style(buf+1);
+      if(j!='B') win_textgrid_styleattrs[i]=t;
+      if(j!='G') win_textbuffer_styleattrs[i]=t;
+      return;
+    }
+  }
+  if(*buf=='/') {
+    /* Filename mapping */
+    Filename_Mapping*fm;
+    char*p;
+    filename_mapping=realloc(filename_mapping,(num_filename_mapping+1)*sizeof(Filename_Mapping));
+    if(!filename_mapping) goto memerr;
+    fm=filename_mapping+num_filename_mapping++;
+    fm->writable=(buf[1]=='/'?1:0);
+    fm->glkname=p=strdup(buf+fm->writable+1);
+    if(!p) goto memerr;
+    while(*p) {
+      if(*p=='=') break;
+      p++;
+    }
+    if(!*p) {
+      printf("Invalid filename mapping\n");
+      exit(1);
+    }
+    *p++=0;
+    fm->native=p;
+    return;
+  }
+  printf("Invalid user option: %s\n",buf);
+  exit(1);
+  memerr:
+  printf("Memory allocation failed\n");
+  exit(1);
+}
+
+static void read_glktermrc(void) {
+  char*home;
+  char*filename=0;
+  FILE*fp;
+  char buf[1024];
+  char*p;
+  int sk=0;
+  filename=getenv("GLKTERMRC");
+  if(filename) {
+    fp=fopen(filename,"r");
+  } else {
+    home=getenv("HOME");
+    if(!home) home=".";
+    filename=malloc(strlen(home)+12);
+    if(!filename) return;
+    sprintf(filename,"%s/.glktermrc",home);
+    fp=fopen(filename,"r");
+    free(filename);
+  }
+  if(!fp) return;
+  while(fgets(buf,1024,fp)) {
+    p=buf+strlen(buf);
+    while(p>buf && (p[-1]=='\r' || p[-1]=='\t' || p[-1]=='\n' || p[-1]==' ')) *--p=0;
+    p=buf;
+    while(*p==' ' || *p=='\t') p++;
+    if(*p=='[' && p[strlen(p)-1]==']') {
+      home=getenv("GLKTERMRC_SECTION");
+      sk=home?strncmp(home,p+1,strlen(p)-2):1;
+    }
+    if(sk) continue;
+    if(*p && *p!='#') user_option(buf);
+  }
+  fclose(fp);
+}
+
 int main(int argc, char *argv[])
 {
     int ix, jx, val;
     glkunix_startup_t startdata;
+    int endflags=0;
     
     /* Test for compile-time errors. If one of these spouts off, you
         must edit glk.h and recompile. */
@@ -53,6 +226,9 @@ int main(int argc, char *argv[])
         printf("Compile-time error: glui32 is not unsigned. Please fix glk.h.\n");
         return 1;
     }
+    
+    /* Read .glktermrc if it exists. */
+    read_glktermrc();
     
     /* Now some argument-parsing. This is probably going to hurt. */
     startdata.argc = 0;
@@ -66,6 +242,14 @@ int main(int argc, char *argv[])
         glkunix_argumentlist_t *argform;
         int inarglist = FALSE;
         char *cx;
+        
+        if(endflags) {
+          startdata.argv[startdata.argc++]=argv[ix];
+          continue;
+        } else if(argv[ix][0]=='-' && argv[ix][1]=='-' && !argv[ix][2]) {
+          endflags=1;
+          continue;
+        }
         
         for (argform = glkunix_arguments; 
             argform->argtype != glkunix_arg_End && !errflag; 
@@ -177,6 +361,8 @@ int main(int argc, char *argv[])
         else if (extract_value(argc, argv, "precise", ex_Bool, &ix, &val, pref_precise_timing))
             pref_precise_timing = val;
 #endif /* !OPT_TIMED_INPUT */
+        else if (!strcmp(argv[ix],"-glkext") && ix<argc-1)
+            user_option(argv[++ix]);
         else {
             printf("%s: unknown option: %s\n", argv[0], argv[ix]);
             errflag = TRUE;


### PR DESCRIPTION
This patch represents the changes that zzo38 made to glkterm as presented  in https://intfiction.org/t/enhanced-glkterm/14049.  I processed that code into something that could be merged into the regular codebase.

Here is a list of some of the new features:

- Can use a .glktermrc file to store user preferences
- Can display “More” when paging
- Support paging when glk_exit() is called
- Colours are supported
- Can set read-only mode; most files opened by Glk fileref functions are read-only
- You can also prohibit all file access entirely
- Filename mapping
- User-definable styles
- Can disable mangling of filenames entered by glk_fileref_create_by_prompt()
- Can set clock skew for the Glk date/time functions
- VT100 line graphics for window borders
- New command-line option – which makes it to treat further arguments as plain arguments (so filenames  can have - at first)
